### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # micro-grad-rs
+
+[![CI](https://github.com/RKeelan/micro-grad-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/RKeelan/micro-grad-rs/actions/workflows/ci.yml)
+
 A Rust implementation of Andrej Karpathy's micrograd: https://github.com/karpathy/micrograd


### PR DESCRIPTION
## Summary
- Add CI status badge to README

## Test plan
- Verify badge renders correctly on GitHub