### PR TITLE
Add cargo-deny for dependency version pinning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+[graph]
+targets = []
+
+[bans]
+# Deny wildcard version specs like "*", ">=0", or missing patch versions
+wildcards = "deny"
+multiple-versions = "warn"
+
+[licenses]
+allow-osi-fsf-free = "either"
+copyleft = "allow"
+default = "allow"
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+notice = "warn"


### PR DESCRIPTION
Adds a `deny.toml` enforcing exact version pins (`wildcards = "deny"` under `[bans]`). Also enables advisory and licence checks.